### PR TITLE
Update public directory to use normalizedPath and update static files…

### DIFF
--- a/src/main/java/me/karakelley/http/filesystem/PublicDirectory.java
+++ b/src/main/java/me/karakelley/http/filesystem/PublicDirectory.java
@@ -50,16 +50,16 @@ public class PublicDirectory {
   }
 
   public String getMimeType(String requestedResource) {
-    File path = getPath(requestedResource).toFile();
+    File path = normalizeFullPath(requestedResource);
     return URLConnection.guessContentTypeFromName(path.getName());
   }
 
   public boolean isFile(String requestedResource) {
-    return getPath(requestedResource).toFile().isFile();
+    return normalizeFullPath(requestedResource).isFile();
   }
 
   public byte[] getFileContents(String requestedResource) {
-    Path file = getPath(requestedResource);
+    Path file = normalizeFullPath(requestedResource).toPath();
     try {
       return Files.readAllBytes(file);
     } catch (IOException e) {
@@ -68,7 +68,7 @@ public class PublicDirectory {
   }
 
   public void createFile(String path, byte[] contents) throws IOException {
-    File newFile = getPath(path).toFile();
+    File newFile = normalizeFullPath(path);
     if (newFile.exists() && (newFile.isFile() || newFile.isDirectory())) throw new IOException();
 
     new File(newFile.getParentFile().getAbsolutePath()).mkdirs();
@@ -87,7 +87,7 @@ public class PublicDirectory {
   }
 
   public void deleteResource(String path) {
-    Path newFile = getPath(path);
+    Path newFile = normalizeFullPath(path).toPath();
     try {
       Files.deleteIfExists(newFile);
     } catch (IOException e) {
@@ -96,7 +96,7 @@ public class PublicDirectory {
   }
 
   public void updateFileContents(String path, byte[] contents) {
-    File newFile = getPath(path).toFile();
+    File newFile = normalizeFullPath(path);
     try (FileOutputStream outputStream = new FileOutputStream(newFile, false)) {
       outputStream.write(contents);
     } catch (IOException e) {

--- a/src/main/java/me/karakelley/http/handlers/staticfilestrategies/RetrieveResourceStrategy.java
+++ b/src/main/java/me/karakelley/http/handlers/staticfilestrategies/RetrieveResourceStrategy.java
@@ -48,7 +48,7 @@ public class RetrieveResourceStrategy implements Handler {
   private Response serveDirectoryResponse(Response response, String requestedResource) {
     Optional<String> indexFile = lookForIndexFile(requestedResource);
     if (indexFile.isPresent()) {
-      return serveFilesResponse(response, "/" + indexFile.get());
+      return serveFilesResponse(response, requestedResource + "/" +indexFile.get());
     }
     response.setBody(getFilesAndDirectoryLinks(requestedResource));
     response.setHeaders(CONTENT_TYPE, TEXT_HTML);

--- a/src/test/java/me/karakelley/http/handlers/StaticFilesHandlerTest.java
+++ b/src/test/java/me/karakelley/http/handlers/StaticFilesHandlerTest.java
@@ -85,6 +85,25 @@ class StaticFilesHandlerTest {
         assertEquals("<p>Index File Present</p>", new String(response.getBody()));
       });
     }
+
+    @Test
+    void servedIndexFileForNestedDirectory() {
+      TempFilesHelper.withTempDirectory(directory -> {
+        Path file = TempFilesHelper.createNestedDirectoryWithFile(directory, "/level2/index.html");
+        TempFilesHelper.createContents("<p>Index File Present at Second Level</p>", file);
+        PublicDirectory publicDirectory = PublicDirectory.create(directory.toString());
+        FilePresenter filePresenter = new HtmlFilePresenter(publicDirectory);
+        Handler handler = new StaticFilesHandler(publicDirectory, filePresenter);
+        Response response = handler.respond(new Request.Builder()
+                .setMethod(HttpMethod.GET)
+                .setPath("/level2")
+                .setProtocol("HTTP/1.1")
+                .setPort(0)
+                .build());
+
+        assertEquals("<p>Index File Present at Second Level</p>", new String(response.getBody()));
+      });
+    }
   }
 
   @Nested

--- a/src/test/java/me/karakelley/http/helpers/TempFilesHelper.java
+++ b/src/test/java/me/karakelley/http/helpers/TempFilesHelper.java
@@ -35,8 +35,19 @@ public class TempFilesHelper {
     try {
       return Files.createFile(Paths.get(directory + name));
     } catch (IOException e) {
-      throw new UncheckedIOException(e);
+      throw new RuntimeException(e);
     }
+  }
+
+  public static Path createNestedDirectoryWithFile(Path directory, String name) {
+    File file = null;
+    try {
+      file = Paths.get(directory + name).toFile().getCanonicalFile();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    new File(Paths.get(directory + name).toFile().getParentFile().getAbsolutePath()).mkdirs();
+    return file.toPath();
   }
 
   public static void createContents(String text, Path file) {


### PR DESCRIPTION
Found a bug where index file wasn't being served in directories beyond the first level which was caused by not sending the full request path to `PublicDirectory` and a test was added to verify. Also updated Public Directory to use normalizedPath for most functions. 